### PR TITLE
Restore config_params for cache_ttl and definitions. Restore default value for port config_params.

### DIFF
--- a/lib/fluent/plugin/in_netflowipfix.rb
+++ b/lib/fluent/plugin/in_netflowipfix.rb
@@ -87,9 +87,11 @@ class PortConnection
 end #class PortConnection
 
 		config_param :tag, :string
-		config_param :port, :integer, default: nil
-		config_param :bind, :string, :default => '0.0.0.0'
+		config_param :port, :integer, default: 5140
+		config_param :bind, :string, default: '0.0.0.0'
 		config_param :queuesleep, :integer, default: 10
+		config_param :cache_ttl, :integer, default: 4000
+		config_param :definitions, :string, default: nil
 
 		def configure(conf)
 			super


### PR DESCRIPTION
For some reason, in b5aa9fa2a0b48ac78f5d2ddf247b61f6b0166067, the `config_params` for `cache_ttl` and `definitions` were removed.

This patch adds them back, which appears to fix #1 and fix #3.

Note: Also switches affected change to Ruby 1.9 hash syntax.